### PR TITLE
chore: improve agent check

### DIFF
--- a/app/middleware/auth.js
+++ b/app/middleware/auth.js
@@ -80,9 +80,9 @@ module.exports = () => {
 
       // check the agent belongs to this app
       const agentId = ctx.query.agentId || ctx.request.body.agentId;
-      const { clients } = await manager.getClients(appId);
-      if (!Array.isArray(clients) || clients.every(client => client.agentId !== agentId)) {
-        return ctx.authFailed(403, '您没有此实例的访问权限');
+      const { client } = await manager.getClient(appId, agentId);
+      if (!client.server) {
+        return ctx.authFailed(403, '此实例尚未连接或者您没有此实例的访问权限');
       }
 
       await next();

--- a/app/service/manager.js
+++ b/app/service/manager.js
@@ -50,6 +50,10 @@ class ManagerService extends Service {
   }
 
   // common manager request
+  getClient(appId, agentId) {
+    return this.request('/xprofiler/client', { appId, agentId }, {});
+  }
+
   getClients(appId) {
     return this.request('/xprofiler/clients', { appId }, {});
   }


### PR DESCRIPTION
`agentAccessibleRequired` 中采用 `getClients` 全量获取当前应用下实例的方式太过粗暴，并且在应用下实例数量比较多（100+）时比较影响针对单个进程的指令操作性能。

这里需要修改为仅判断当前请求的 `agent` 是否在应用下即可。